### PR TITLE
fix: botão de tema bilíngue (PT/EN)

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -171,12 +171,22 @@
      * @param {string} theme
      */
     _updateText: function(theme) {
-      const text = theme === 'light' ? 'Modo escuro' : 'Modo claro';
+      // Verifica idioma atual para textos bilíngues
+      const currentLang = window.App.I18n ? window.App.I18n.getCurrentLang() : 'pt';
+      const isEnglish = currentLang === 'en';
+
+      // Textos bilíngues para o botão de tema
+      const text = isEnglish
+        ? (theme === 'light' ? 'Dark mode' : 'Light mode')
+        : (theme === 'light' ? 'Modo escuro' : 'Modo claro');
+
       this._elements.text.textContent = text;
 
-      // Atualiza aria-pressed e aria-label para acessibilidade
+      // Atualiza aria-pressed e aria-label bilíngue para acessibilidade
       this._elements.toggle.setAttribute('aria-pressed', theme === 'dark');
-      const ariaLabel = theme === 'light' ? 'Ativar modo escuro' : 'Ativar modo claro';
+      const ariaLabel = isEnglish
+        ? (theme === 'light' ? 'Enable dark mode' : 'Enable light mode')
+        : (theme === 'light' ? 'Ativar modo escuro' : 'Ativar modo claro');
       this._elements.toggle.setAttribute('aria-label', ariaLabel);
     },
 


### PR DESCRIPTION
## Summary

Corrige o botão de tema para exibir textos no idioma correto (PT/EN).

## Problema

O botão de tema estava sempre em português, mesmo quando o site estava em inglês.

## Solução

Adiciona verificação do idioma atual via `window.App.I18n.getCurrentLang()` antes de definir o texto:

| Idioma | Modo Claro → Escuro | Modo Escuro → Claro |
|--------|---------------------|---------------------|
| 🇧🇷 PT | "Modo escuro" | "Modo claro" |
| 🇺🇸 EN | "Dark mode" | "Light mode" |

## Mudanças

- `_updateText()` agora verifica o idioma atual
- Textos bilíngues para PT e EN
- Aria-labels também atualizados dinamicamente

## Checklist

- [x] Botão respeita idioma atual
- [x] Aria-labels bilíngues
- [x] Testado em ambos os idiomas

🤖 Generated with [Claude Code](https://claude.com/claude-code)