### PR TITLE
fix: sincroniza botão de tema com mudança de idioma

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -194,6 +194,13 @@
 
       // Alterna visibilidade dos elementos
       this._toggleElements(safeLang);
+
+      // Dispara evento para notificar outros módulos
+      if (typeof document !== 'undefined') {
+        const event = document.createEvent('CustomEvent');
+        event.initCustomEvent('languageChanged', true, true, { lang: safeLang });
+        document.dispatchEvent(event);
+      }
     },
 
     /**

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -106,6 +106,11 @@
           self._handleToggle();
         }
       });
+
+      // Atualiza quando o idioma muda
+      document.addEventListener('languageChanged', function() {
+        self._updateText(self.getCurrentTheme());
+      });
     },
 
     /**


### PR DESCRIPTION
## Summary

Corrige sincronização do botão de tema ao mudar idioma do site.

## Problema

Quando o usuário mudava o idioma (PT ↔ EN), o botão de tema só atualizava o texto quando o usuário clicava nele, não imediatamente na troca de idioma.

## Solução

Implementa comunicação via eventos entre módulos:

### i18n.js
- Dispara evento `languageChanged` ao trocar idioma
- Evento contém o novo idioma selecionado

### theme.js  
- Escuta evento `languageChanged` no document
- Atualiza texto do botão instantaneamente
- Mantém funcionalidade bilíngue

## Comportamento Esperado

| Ação | Antes | Depois |
|------|-------|--------|
| Mudar PT → EN | Botão permanece em PT | Botão muda para EN imediatamente |
| Mudar EN → PT | Botão permanece em EN | Botão muda para PT imediatamente |

## Checklist

- [x] Evento disparado ao mudar idioma
- [x] Theme escuta e atualiza automaticamente
- [x] Texto bilíngue funciona corretamente
- [x] Sem regressões no comportamento do tema

🤖 Generated with [Claude Code](https://claude.com/claude-code)