### PR TITLE
fix: adiciona cloudflareinsights.com à CSP

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -38,7 +38,7 @@
   }
   </script>
 
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https:; connect-src 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://fonts.googleapis.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https:; connect-src 'self' https://cloudflareinsights.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
 
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-XSS-Protection" content="1; mode=block">


### PR DESCRIPTION
## Summary
O script de analytics do Cloudflare estava sendo bloqueado pela Content Security Policy, gerando erro no console:

```
Refused to load the script 'https://static.cloudflareinsights.com/beacon.min.js/...'
because it violates the following Content Security Policy directive: "script-src 'self' https://fonts.googleapis.com"
```

## Changes
- Adiciona `https://static.cloudflareinsights.com` ao `script-src`
- Adiciona `https://cloudflareinsights.com` ao `connect-src` (para as requisições POST do beacon)

## Test plan
- [x] Verificar se não há mais erros de CSP no console
- [x] Verificar se o analytics do Cloudflare está funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)