### PR TITLE
feat: detecção automática de idioma

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -135,14 +135,42 @@
     },
 
     /**
-     * Carrega idioma salvo
+     * Carrega idioma salvo ou detecta do navegador
      * @private
      */
     _loadSavedLanguage: function() {
-      const savedLang = App.Utils.Storage.get(this.STORAGE_KEY, this.DEFAULT_LANG);
-      const validLang = this._validateLang(savedLang);
+      const savedLang = App.Utils.Storage.get(this.STORAGE_KEY);
 
+      // Se não houver idioma salvo, detecta pelo navegador
+      if (!savedLang) {
+        const detectedLang = this._detectBrowserLanguage();
+        this._applyLanguage(detectedLang);
+        return;
+      }
+
+      const validLang = this._validateLang(savedLang);
       this._applyLanguage(validLang);
+    },
+
+    /**
+     * Detecta idioma do navegador
+     * @private
+     * @returns {string}
+     */
+    _detectBrowserLanguage: function() {
+      try {
+        // Pega o idioma primário do navegador (ex: "pt-BR", "en-US")
+        const browserLang = navigator.language || navigator.userLanguage || 'pt';
+
+        // Se começar com 'pt', usa português, senão usa inglês
+        if (browserLang.toLowerCase().startsWith('pt')) {
+          return 'pt';
+        }
+
+        return 'en';
+      } catch (error) {
+        return this.DEFAULT_LANG;
+      }
     },
 
     /**


### PR DESCRIPTION
## Summary
Detecta automaticamente o idioma do navegador do usuário na primeira visita para carregar o site no idioma apropriado.

## Como funciona
- Detecta `navigator.language` (ex: "pt-BR", "en-US", "es-ES")
- Se começar com "pt" → carrega em **Português**
- Qualquer outro idioma → carrega em **Inglês**
- Se o usuário já tiver escolhido manualmente antes, respeita essa preferência (salva no localStorage)

## Exemplos
| Idioma do navegador | Idioma carregado |
|---------------------|------------------|
| pt-BR | Português |
| pt-PT | Português |
| en-US | Inglês |
| es-ES | Inglês |
| fr-FR | Inglês |
| de-DE | Inglês |

## Test plan
- [x] Limpar localStorage e abrir o site com navegador em português → deve carregar em PT
- [x] Limpar localStorage e abrir o site com navegador em inglês → deve carregar em EN
- [x] Alterar idioma manualmente, recarregar → deve manter a escolha manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)