### PR TITLE
feat: define inglês e dark mode como padrão sem JavaScript

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 {{define "index"}}<!DOCTYPE html>
-<html lang="pt-BR" data-theme="light">
+<html lang="en" data-theme="dark">
 {{template "head" .}}
 <body>
   <a href="#main-content" class="skip-link">
@@ -26,7 +26,7 @@
 
   <noscript>
     <style>
-      .lang-en { display: none !important; }
+      .lang-pt { display: none !important; }
       .accordion .accordion-content { max-height: none !important; padding: 24px 0 !important; }
       .accordion-header { cursor: default !important; }
       .accordion-icon { display: none !important; }


### PR DESCRIPTION
## Summary

Altera o comportamento padrão do site quando JavaScript está desabilitado. Agora o site aparece em **inglês** com **tema escuro** por padrão (antes era português + tema claro).

## Mudanças

- Altera `<html>` para `lang=\"en\"` (era `pt-BR`)
- Altera `<html>` para `data-theme=\"dark\"` (era `light`)
- Inverte `<noscript>` para esconder `.lang-pt` em vez de `.lang-en`

## Comportamento

| Cenário | Resultado |
|---------|-----------|
| Sem JavaScript | Inglês + Dark mode |
| Com JavaScript | Toggle funciona normalmente |

## Testes

- [x] Build local executado com sucesso
- [x] HTML gerado com `lang=\"en\"` e `data-theme=\"dark\"`
- [x] Noscript esconde conteúdo em português

🤖 Generated with [Claude Code](https://claude.ai/claude-code)