### PR TITLE
ci: usa go-version-file para evitar warning de deprecação

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Download dependencies


### PR DESCRIPTION
## Summary

Corrige o warning `DEP0040` do módulo `punycode` que aparecia no setup do Go.

## Mudança

- Substitui `go-version: '1.21'` por `go-version-file: 'go.mod'`
- Agora o workflow usa automaticamente a versão definida no `go.mod` (1.24.0)
- Elimina o warning de deprecação

## Vantagens

- Sincronização automática entre go.mod e workflow
- Uma fonte única de verdade para a versão do Go
- Evita warnings de deprecação

🤖 Generated with [Claude Code](https://claude.ai/claude-code)