### PR TITLE
feat: altera cor de fundo para tom de post-it branco

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,12 +8,12 @@
 }
 
 :root {
-  --bg-color: #ffffff;
+  --bg-color: #fefcf3;
   --text-color: #1a1a1a;
   --text-secondary: #666666;
-  --border-color: #e5e5e5;
+  --border-color: #e8e4d9;
   --accent-color: #1a1a1a;
-  --hover-bg: #f5f5f5;
+  --hover-bg: #f5f3eb;
 }
 
 [data-theme="dark"] {


### PR DESCRIPTION
## Summary

Altera a cor de fundo do tema claro para um tom próximo de post-it branco/amarelado.

## Mudanças

| Variável | Antes | Depois | Descrição |
|----------|-------|--------|-----------|
| `--bg-color` | `#ffffff` | `#fefcf3` | Branco creme/amarelado |
| `--border-color` | `#e5e5e5` | `#e8e4d9` | Tom mais quente |
| `--hover-bg` | `#f5f5f5` | `#f5f3eb` | Tom mais quente |

## Visual

- **Antes**: Branco puro (#ffffff)
- **Depois**: Branco com tom creme/amarelado (#fefcf3), similar a um post-it

O tema escuro não foi alterado.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)