### PR TITLE
fix: corrige ícone do tema em dispositivos móveis

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -144,6 +144,13 @@ body {
   color: var(--text-color);
 }
 
+.theme-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  display: block;
+}
+
 /* Header controls */
 .header-controls {
   display: flex;

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -6,7 +6,7 @@
       <span id="lang-text">EN</span>
     </button>
     <button class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ativar modo escuro" title="Ativar modo escuro">
-      <svg class="theme-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <svg class="theme-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
         <circle cx="12" cy="12" r="5"></circle>
         <line x1="12" y1="1" x2="12" y2="3"></line>
         <line x1="12" y1="21" x2="12" y2="23"></line>


### PR DESCRIPTION
## Summary

Correção para o ícone do tema não aparecer em dispositivos móveis.

### Problema
O ícone do sol não estava sendo renderizado no mobile (iPhone/Android).

### Solução
- Adiciona dimensões explícitas `width="20" height="20"` no SVG do ícone
- Adiciona estilos CSS `.theme-icon` com:
  - `width: 20px; height: 20px` - dimensões fixas
  - `flex-shrink: 0` - evita encolhimento em flexbox
  - `display: block` - garante renderização consistente

### Testes
- [x] Validado em viewport mobile (375x667)
- [x] Ícone aparece corretamente no header

## Screenshots

Antes: Ícone do tema invisível em mobile
Depois: Ícone do tema visível com dimensões corretas

🤖 Generated with Claude Code