### PR TITLE
fix: atualiza Node.js para v22 no workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: .github/scripts


### PR DESCRIPTION
Corrige versão do Node.js de 20 para 22 no workflow de release, pois o semantic-release v25 requer Node.js ^22.14.0.