### PR TITLE
fix: adiciona tokens ao workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Determine next version
         working-directory: .github/scripts
         id: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # Instalar semantic-release
           npm install -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator


### PR DESCRIPTION
Adiciona GITHUB_TOKEN e NPM_TOKEN como variáveis de ambiente no step 'Determine next version', pois o semantic-release precisa desses tokens para analisar commits e determinar a próxima versão.