### PR TITLE
fix: adiciona .releaserc.json na raiz

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,47 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {"type": "feat", "release": "minor"},
+          {"type": "fix", "release": "patch"},
+          {"type": "docs", "release": "patch"},
+          {"type": "style", "release": "patch"},
+          {"type": "refactor", "release": "patch"},
+          {"type": "perf", "release": "patch"},
+          {"type": "test", "release": "patch"},
+          {"type": "chore", "release": "patch"},
+          {"breaking": true, "release": "major"}
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {"type": "feat", "section": "✨ Adicionado"},
+            {"type": "fix", "section": "🐛 Corrigido"},
+            {"type": "docs", "section": "📝 Documentação"},
+            {"type": "style", "section": "💎 Estilo"},
+            {"type": "refactor", "section": "♻️ Alterado"},
+            {"type": "perf", "section": "⚡ Performance"},
+            {"type": "test", "section": "✅ Testes"},
+            {"type": "chore", "section": "🔧 Manutenção"}
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
Adiciona configuração do semantic-release na raiz do projeto, sem o plugin npm (que requer token NPM), mantendo apenas plugins essenciais para análise de commits e geração de tags/releases.