### PR TITLE
fix: caminho para .releaserc.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           npm install -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator
 
           # Executar semantic-release em modo dry-run para obter próxima versão
-          npx semantic-release --dry-run --branches main 2>&1 | tee output.log || true
+          npx semantic-release --dry-run --branches main --config ../../.releaserc.json 2>&1 | tee output.log || true
 
           # Extrair versão do output
           VERSION=$(grep -oP 'Published release \K[0-9]+\.[0-9]+\.[0-9]+' output.log || echo "")


### PR DESCRIPTION
Adiciona caminho explícito para o arquivo .releaserc.json no comando semantic-release, já que o workflow executa de dentro de .github/scripts.