### PR TITLE
fix: corrige ícones de tema claro/escuro

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -151,6 +151,24 @@ body {
   display: block;
 }
 
+/* Ícone de lua visível no tema claro */
+.theme-icon-moon {
+  display: block;
+}
+
+.theme-icon-sun {
+  display: none;
+}
+
+/* Ícone de sol visível no tema escuro */
+[data-theme="dark"] .theme-icon-moon {
+  display: none;
+}
+
+[data-theme="dark"] .theme-icon-sun {
+  display: block;
+}
+
 /* Header controls */
 .header-controls {
   display: flex;

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -6,7 +6,12 @@
       <span id="lang-text">EN</span>
     </button>
     <button class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ativar modo escuro" title="Ativar modo escuro">
-      <svg class="theme-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <!-- Ícone de lua - visível no tema claro -->
+      <svg class="theme-icon theme-icon-moon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+      </svg>
+      <!-- Ícone de sol - visível no tema escuro -->
+      <svg class="theme-icon theme-icon-sun" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
         <circle cx="12" cy="12" r="5"></circle>
         <line x1="12" y1="1" x2="12" y2="3"></line>
         <line x1="12" y1="21" x2="12" y2="23"></line>


### PR DESCRIPTION
Corrige a exibição dos ícones de tema:\n\n- Tema claro (light): mostra ícone de lua 🌙\n- Tema escuro (dark): mostra ícone de sol ☀️\n\nAnteriormente o ícone de sol era exibido em ambos os temas. Agora cada tema mostra o ícone que sugere a alternativa (lua para escuro, sol para claro).