### PR TITLE
feat: fade-in em todas as seções e SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ This is a static personal website, and we prioritize security in all deployments
 If you discover a security vulnerability in this project, please report it responsibly:
 
 1. **Do NOT** open a public issue
-2. Send an email to: **security@vagnerbarbosa.com**
+2. Send an email to: **contato@vagnerbarbosa.com**
 3. Include details about the vulnerability and steps to reproduce
 4. Allow reasonable time for response before public disclosure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Supported Versions
+
+This is a static personal website, and we prioritize security in all deployments. The following versions are actively supported with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.x.x   | :white_check_mark: |
+| 3.x.x   | :x:                |
+| 2.x.x   | :x:                |
+| 1.x.x   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly:
+
+1. **Do NOT** open a public issue
+2. Send an email to: **security@vagnerbarbosa.com**
+3. Include details about the vulnerability and steps to reproduce
+4. Allow reasonable time for response before public disclosure
+
+## Security Measures
+
+This project implements the following security practices:
+
+### Content Security
+- HTML templates use Go's `html/template` package with auto-escaping to prevent XSS
+- No `safeHTML` or raw HTML injection from user-provided content
+- Input sanitization on all rendered content
+
+### CI/CD Security
+- GitHub Actions workflows run with minimum required permissions (principle of least privilege)
+- No write permissions where only read is needed
+- Secure polling mechanisms with backoff instead of fixed delays
+
+### Dependencies
+- Regular updates to dependencies via Dependabot
+- Minimal dependency surface (Go standard library + minify)
+- No JavaScript runtime dependencies in production
+
+### Headers
+The following security headers are configured:
+
+- **Content-Security-Policy (CSP)**: Restricts content sources
+- **X-Frame-Options: DENY**: Prevents clickjacking
+- **X-Content-Type-Options: nosniff**: Prevents MIME type sniffing
+- **Referrer-Policy**: Controls referrer information
+
+## Acknowledgments
+
+We appreciate responsible disclosure of security issues. Contributors who report valid vulnerabilities will be acknowledged (with permission).
+
+---
+
+Last updated: April 2026

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -1,5 +1,5 @@
 {{define "about"}}
-<div class="accordion expanded" id="about">
+<div class="accordion expanded fade-in fade-in-delay-1" id="about">
   <button class="accordion-header" aria-expanded="true">
     <span class="accordion-header-content">
       <span class="lang-pt"><span class="bracket">[</span>Sobre<span class="bracket">]</span></span>

--- a/templates/partials/contact.html
+++ b/templates/partials/contact.html
@@ -1,5 +1,5 @@
 {{define "contact"}}
-<div class="accordion" id="contact">
+<div class="accordion fade-in fade-in-delay-5" id="contact">
   <button class="accordion-header" aria-expanded="false">
     <span class="accordion-header-content">
       <span class="lang-pt"><span class="bracket">[</span>Contato<span class="bracket">]</span></span>

--- a/templates/partials/education.html
+++ b/templates/partials/education.html
@@ -1,5 +1,5 @@
 {{define "education"}}
-<div class="accordion" id="education">
+<div class="accordion fade-in fade-in-delay-4" id="education">
   <button class="accordion-header" aria-expanded="false">
     <span class="accordion-header-content">
       <span class="lang-pt"><span class="bracket">[</span>Formação<span class="bracket">]</span></span>

--- a/templates/partials/experience.html
+++ b/templates/partials/experience.html
@@ -1,5 +1,5 @@
 {{define "experience"}}
-<div class="accordion" id="experience">
+<div class="accordion fade-in fade-in-delay-2" id="experience">
   <button class="accordion-header" aria-expanded="false">
     <span class="accordion-header-content">
       <span class="lang-pt"><span class="bracket">[</span>Experiência<span class="bracket">]</span></span>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,5 +1,5 @@
 {{define "footer"}}
-<footer>
+<footer class="fade-in fade-in-delay-5">
   <p>&copy; {{.Year}} {{.Site.Username}}</p>
 </footer>
 {{end}}

--- a/templates/partials/skills.html
+++ b/templates/partials/skills.html
@@ -1,5 +1,5 @@
 {{define "skills"}}
-<div class="accordion" id="skills">
+<div class="accordion fade-in fade-in-delay-3" id="skills">
   <button class="accordion-header" aria-expanded="false">
     <span class="accordion-header-content">
       <span class="lang-pt"><span class="bracket">[</span>Tecnologias<span class="bracket">]</span></span>


### PR DESCRIPTION
## Summary

Ajustes adicionais após o merge da PR #108:

- Adiciona efeito fade-in em todas as seções do site (não apenas no header)
- Adiciona SECURITY.md com política de segurança

### Mudanças

**Fade-in em todas as seções:**
- `templates/partials/about.html`: `fade-in fade-in-delay-1`
- `templates/partials/experience.html`: `fade-in fade-in-delay-2`
- `templates/partials/skills.html`: `fade-in fade-in-delay-3`
- `templates/partials/education.html`: `fade-in fade-in-delay-4`
- `templates/partials/contact.html`: `fade-in fade-in-delay-5`
- `templates/partials/footer.html`: `fade-in fade-in-delay-5`

**Nova documentação:**
- `SECURITY.md`: Política de segurança, relatório de vulnerabilidades e medidas implementadas

### Nota sobre Vulnerabilidades do Dependabot

As vulnerabilidades listadas afetam pacotes JavaScript em `.github/scripts/node_modules` (ferramentas auxiliares do Spec Kit), não o código de produção. O site é 100% estático gerado por Go, sem runtime JavaScript no servidor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)